### PR TITLE
update regex for parsing hostnames

### DIFF
--- a/installpresto.sh
+++ b/installpresto.sh
@@ -9,7 +9,7 @@ if [[ "$ISSUPPORTED" != "True" ]]; then
 fi
 
 # check if we have atleast 4 nodes
-nodes=$(curl -L http://headnodehost:8088/ws/v1/cluster/nodes |  grep -o '"nodeHostName":"[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*"'  | wc -l)
+nodes=$(curl -L http://headnodehost:8088/ws/v1/cluster/nodes |  grep -o '"nodeHostName":"[^\.\s"]*\.[^\.\s"]*\.[^\.\s"]*\.[^\s"]*"' | wc -l)
 if [[ $nodes -lt 4 ]]; then 
   echo "you need atleast 4 node hadoop cluster to run presto on HDI. Aborting."
   exit 1


### PR DESCRIPTION
currently on HDI cluster we actual get hostname (not ip address) which seem to consist of 4+ parts (6 in my test cluster)
replacing plain ip4 address regex with more relaxed 4+ namepart parsing.

Ideally this should be replaced with python srcipt (default shell doesn't seem to have robast error handling by default or additional tools need to be installed. 
But in this case we are just counting nodes (just counting "hostnodeHostName": would be enough)